### PR TITLE
Fix inventory increase bug

### DIFF
--- a/src/main/java/iet/hf/monkesoft/electric/boogaloo/InventoryIncrease.java
+++ b/src/main/java/iet/hf/monkesoft/electric/boogaloo/InventoryIncrease.java
@@ -26,11 +26,7 @@ public class InventoryIncrease extends Effect {
 	 */
 	@Override
 	public void Apply(Virologist v) {
-<<<<<<< Updated upstream
-		v.getMaterialList().forEach( (m) -> m.IncreaseMax(m.getMax()));
-=======
 		v.getMaterialList().forEach( m -> m.IncreaseMax(m.getOriginalMax()));
->>>>>>> Stashed changes
 		new AppliedEffect(v, this, -1);
 	}
 	
@@ -41,12 +37,6 @@ public class InventoryIncrease extends Effect {
 	@Override
 	public void Die(Virologist v) {
 		v.RemoveEffect(this);
-<<<<<<< Updated upstream
-		for (int i = 0; i < v.getMaterialList().size(); i++) {
-			v.getMaterialList().forEach( (m) -> m.DecreaseMax(m.getMax()));
-		}
-=======
 		v.getMaterialList().forEach( m -> m.DecreaseMax(m.getOriginalMax()));
->>>>>>> Stashed changes
 	}
 }

--- a/src/main/java/iet/hf/monkesoft/electric/boogaloo/InventoryIncrease.java
+++ b/src/main/java/iet/hf/monkesoft/electric/boogaloo/InventoryIncrease.java
@@ -26,7 +26,11 @@ public class InventoryIncrease extends Effect {
 	 */
 	@Override
 	public void Apply(Virologist v) {
+<<<<<<< Updated upstream
 		v.getMaterialList().forEach( (m) -> m.IncreaseMax(m.getMax()));
+=======
+		v.getMaterialList().forEach( m -> m.IncreaseMax(m.getOriginalMax()));
+>>>>>>> Stashed changes
 		new AppliedEffect(v, this, -1);
 	}
 	
@@ -37,8 +41,12 @@ public class InventoryIncrease extends Effect {
 	@Override
 	public void Die(Virologist v) {
 		v.RemoveEffect(this);
+<<<<<<< Updated upstream
 		for (int i = 0; i < v.getMaterialList().size(); i++) {
 			v.getMaterialList().forEach( (m) -> m.DecreaseMax(m.getMax()));
 		}
+=======
+		v.getMaterialList().forEach( m -> m.DecreaseMax(m.getOriginalMax()));
+>>>>>>> Stashed changes
 	}
 }

--- a/src/main/java/iet/hf/monkesoft/electric/boogaloo/JAxe.java
+++ b/src/main/java/iet/hf/monkesoft/electric/boogaloo/JAxe.java
@@ -1,7 +1,6 @@
 package iet.hf.monkesoft.electric.boogaloo;
 
 import javax.swing.*;
-import java.awt.*;
 import java.awt.event.MouseEvent;
 
 /**

--- a/src/main/java/iet/hf/monkesoft/electric/boogaloo/JEquipment.java
+++ b/src/main/java/iet/hf/monkesoft/electric/boogaloo/JEquipment.java
@@ -1,7 +1,6 @@
 package iet.hf.monkesoft.electric.boogaloo;
 
 import javax.swing.*;
-import java.awt.*;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 

--- a/src/main/java/iet/hf/monkesoft/electric/boogaloo/JGeneticCode.java
+++ b/src/main/java/iet/hf/monkesoft/electric/boogaloo/JGeneticCode.java
@@ -1,7 +1,6 @@
 package iet.hf.monkesoft.electric.boogaloo;
 
 import javax.swing.*;
-import java.awt.*;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 

--- a/src/main/java/iet/hf/monkesoft/electric/boogaloo/Material.java
+++ b/src/main/java/iet/hf/monkesoft/electric/boogaloo/Material.java
@@ -31,6 +31,7 @@ public abstract class Material {
 	 *Az objektum Ăˇltal reprezentĂˇlhatĂł maximĂˇlis anyagmennyisĂ©g valamilyen okbĂłl nĹ‘tt (tipikusan akkor, ha egy VirolĂłgus objektumra felkerĂĽlt valamilyen effekt, ami a maximĂˇlis anyaggyĹ±jtĹ‘ kĂ©pessĂ©get nĂ¶veli).
 	 */
 	public void IncreaseMax(int i) {
+
 		MaxAmount=(MaxAmount+i);
 	}
 	
@@ -40,6 +41,9 @@ public abstract class Material {
 	 */
 	public void DecreaseMax(int i) {
 		MaxAmount=(MaxAmount-i);
+		if (Amount > MaxAmount){
+			Amount = MaxAmount;
+		}
 	}
 
 	/**
@@ -111,5 +115,7 @@ public abstract class Material {
 		return MaxAmount;
 	}
 	
-	
+	public int getOriginalMax(){
+		return MAX;
+	}
 }


### PR DESCRIPTION
Az inventory increase effekt megszűnésénél nem csökkent a tárolt érték max értékére, amennyiben addig meghaladta azt + kétszer történt meg a visszacsökkentés